### PR TITLE
Add multiplayer melody sync

### DIFF
--- a/src/main/java/net/conczin/YmmersiveMelodies.java
+++ b/src/main/java/net/conczin/YmmersiveMelodies.java
@@ -6,9 +6,13 @@ import com.hypixel.hytale.component.ResourceType;
 import com.hypixel.hytale.server.core.asset.HytaleAssetStore;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Interaction;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.server.OpenCustomUIInteraction;
+import com.hypixel.hytale.server.core.Constants;
+import com.hypixel.hytale.server.core.HytaleServer;
+import com.hypixel.hytale.server.core.modules.singleplayer.SingleplayerRequestAccessEvent;
 import com.hypixel.hytale.server.core.plugin.JavaPlugin;
 import com.hypixel.hytale.server.core.plugin.JavaPluginInit;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.hypixel.hytale.protocol.packets.serveraccess.Access;
 import net.conczin.data.MelodyAsset;
 import net.conczin.data.MelodyPlaybackInteraction;
 import net.conczin.data.YmmersiveMelodiesRegistry;
@@ -53,6 +57,13 @@ public class YmmersiveMelodies extends JavaPlugin {
                 "Ymmersive_Melodies_Selection",
                 MelodySelectionSupplier.class,
                 MelodySelectionSupplier.CODEC);
+
+        if (Constants.SINGLEPLAYER) {
+            HytaleServer.get().getEventBus()
+                    .register(SingleplayerRequestAccessEvent.class, event ->
+                            MelodyPlaybackInteraction.setMultiplayerMode(event.getAccess() != Access.Private)
+                    );
+        }
     }
 
     public static YmmersiveMelodies getInstance() {

--- a/src/main/java/net/conczin/data/Melody.java
+++ b/src/main/java/net/conczin/data/Melody.java
@@ -7,14 +7,18 @@ import net.conczin.utils.RecordCodec;
 import java.util.Collections;
 import java.util.List;
 
-public record Melody(String name, List<Track> tracks) {
+public record Melody(String name, List<Track> tracks, int duration) {
+    public Melody(String name, List<Track> tracks) {
+        this(name, tracks, computeDuration(tracks));
+    }
+
     public static final RecordCodec<Melody> CODEC = RecordCodec.composite(
             "Name", Codec.STRING, Melody::name,
             "Tracks", new ListCodec<>(Track.CODEC), Melody::tracks,
             Melody::new
     );
 
-    public int duration() {
+    private static int computeDuration(List<Track> tracks) {
         int max = 0;
         for (Track track : tracks) {
             for (Note note : track.notes()) {

--- a/src/main/java/net/conczin/data/Melody.java
+++ b/src/main/java/net/conczin/data/Melody.java
@@ -37,7 +37,7 @@ public record Melody(String name, List<Track> tracks) {
                 "Note", Codec.INTEGER, Note::note,
                 "Velocity", Codec.INTEGER, Note::velocity,
                 "Time", Codec.INTEGER, Note::time,
-                "Length", Codec.INTEGER, Note::time,
+                "Length", Codec.INTEGER, Note::length,
                 Note::new
         );
 

--- a/src/main/java/net/conczin/data/Melody.java
+++ b/src/main/java/net/conczin/data/Melody.java
@@ -14,6 +14,17 @@ public record Melody(String name, List<Track> tracks) {
             Melody::new
     );
 
+    public int duration() {
+        int max = 0;
+        for (Track track : tracks) {
+            for (Note note : track.notes()) {
+                int end = note.time() + note.length();
+                if (end > max) max = end;
+            }
+        }
+        return max;
+    }
+
     public record Track(String name, List<Note> notes) {
         public static final RecordCodec<Track> CODEC = RecordCodec.composite(
                 "Name", Codec.STRING, Track::name,

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -178,7 +178,7 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
         }
 
         // Auto-stop: song finished, clear melody
-        if (progress.time > duration) {
+        if (progress.time >= duration) {
             if (multiplayerMode) {
                 MelodySyncRegistry.removePlayer(uuid, progress.melody);
             }

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -139,13 +139,6 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
             progress.worldTime = timeMs;
             progress.time = playbackTime;
         } else {
-            // Singleplayer: warmup on first tick
-            if (progress.worldTime == 0) {
-                progress.worldTime = timeMs;
-                saveProgress(context, itemInHand, progress);
-                return;
-            }
-
             prevPlaybackTime = progress.time;
             delta = Math.min(timeMs - progress.worldTime, buffer);
             if (delta <= 0) return;

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -102,16 +102,14 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
 
         UUID uuid = Utils.getUUID(ref);
 
+        int duration = melody.duration();
+
         // Sync: initialize shared time anchor on first tick
         if (progress.startWorldTime == 0) {
-            progress.startWorldTime = MelodySyncRegistry.getOrCreateAnchor(uuid, progress.melody, position, timeMs, melody.duration());
+            progress.startWorldTime = MelodySyncRegistry.getOrCreateAnchor(uuid, progress.melody, position, timeMs, duration);
             progress.worldTime = timeMs;
             progress.time = 0;
-            ItemStack newItemInHand = itemInHand.withMetadata("MelodyProgress", MelodyProgress.CODEC, progress);
-            ItemContainer container = context.getHeldItemContainer();
-            if (container != null) {
-                container.replaceItemStackInSlot(context.getHeldItemSlot(), itemInHand, newItemInHand);
-            }
+            saveProgress(context, itemInHand, progress);
             return;
         }
 
@@ -158,13 +156,17 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
         progress.time = playbackTime;
 
         // Auto-stop: song finished, clear melody
-        if (playbackTime > melody.duration()) {
+        if (playbackTime > duration) {
             MelodySyncRegistry.removePlayer(uuid, progress.melody);
             progress.melody = "";
             progress.time = 0;
             progress.startWorldTime = 0;
         }
 
+        saveProgress(context, itemInHand, progress);
+    }
+
+    private static void saveProgress(InteractionContext context, ItemStack itemInHand, MelodyProgress progress) {
         ItemStack newItemInHand = itemInHand.withMetadata("MelodyProgress", MelodyProgress.CODEC, progress);
         ItemContainer container = context.getHeldItemContainer();
         if (container != null) {

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -23,6 +23,7 @@ import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Sim
 import com.hypixel.hytale.server.core.modules.time.TimeResource;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import net.conczin.utils.Utils;
 
 import javax.annotation.Nonnull;
 import java.time.Instant;
@@ -78,16 +79,12 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
         MelodyProgress progress = itemInHand.getFromMetadataOrDefault("MelodyProgress", MelodyProgress.CODEC);
         if (progress.melody.isEmpty()) return;
 
-        // TODO: Sync
-
         // This should be the tick rate plus max jitter margin
         long buffer = 150L;
 
         // Get time
         Instant timeResource = store.getResource(TimeResource.getResourceType()).getNow();
         long timeMs = timeResource.getEpochSecond() * 1000L + timeResource.getNano() / 1_000_000L;
-        long delta = Math.min(timeMs - progress.worldTime, buffer);
-        if (delta <= 0) return;
 
         // Get melody
         Melody melody;
@@ -103,12 +100,36 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
 
         if (melody == null) return;
 
+        UUID uuid = Utils.getUUID(ref);
+
+        // Sync: initialize shared time anchor on first tick
+        if (progress.startWorldTime == 0) {
+            progress.startWorldTime = MelodySyncRegistry.getOrCreateAnchor(uuid, progress.melody, position, timeMs, melody.duration());
+            progress.worldTime = timeMs;
+            progress.time = 0;
+            ItemStack newItemInHand = itemInHand.withMetadata("MelodyProgress", MelodyProgress.CODEC, progress);
+            ItemContainer container = context.getHeldItemContainer();
+            if (container != null) {
+                container.replaceItemStackInSlot(context.getHeldItemSlot(), itemInHand, newItemInHand);
+            }
+            return;
+        }
+
+        // Sync: derive playback position from shared anchor
+        long playbackTime = timeMs - progress.startWorldTime;
+        long prevPlaybackTime = progress.worldTime - progress.startWorldTime;
+        long delta = Math.min(playbackTime - prevPlaybackTime, buffer);
+        if (delta <= 0) return;
+
+        // Keep the sync session alive
+        MelodySyncRegistry.keepAlive(uuid, progress.melody, progress.startWorldTime, position, timeMs);
+
         // Play notes
         for (Melody.Track track : melody.tracks()) {
             // TODO: Track filter
             for (Melody.Note note : track.notes()) {
-                if (note.time() >= progress.time && note.time() < progress.time + delta) {
-                    long delay = note.time() - (progress.time + delta) + buffer;
+                if (note.time() >= prevPlaybackTime && note.time() < prevPlaybackTime + delta) {
+                    long delay = note.time() - (prevPlaybackTime + delta) + buffer;
                     if (delay <= 0) continue;
 
                     float volume = note.velocity() / 64.0f;
@@ -134,7 +155,7 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
 
         // Update states
         progress.worldTime = timeMs;
-        progress.time += delta;
+        progress.time = playbackTime;
         ItemStack newItemInHand = itemInHand.withMetadata("MelodyProgress", MelodyProgress.CODEC, progress);
         ItemContainer container = context.getHeldItemContainer();
         if (container != null) {

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -156,6 +156,15 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
         // Update states
         progress.worldTime = timeMs;
         progress.time = playbackTime;
+
+        // Auto-stop: song finished, clear melody
+        if (playbackTime > melody.duration()) {
+            MelodySyncRegistry.removePlayer(uuid, progress.melody);
+            progress.melody = "";
+            progress.time = 0;
+            progress.startWorldTime = 0;
+        }
+
         ItemStack newItemInHand = itemInHand.withMetadata("MelodyProgress", MelodyProgress.CODEC, progress);
         ItemContainer container = context.getHeldItemContainer();
         if (container != null) {

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -107,8 +107,6 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
 
         if (melody == null) return;
 
-        UUID uuid = Utils.getUUID(ref);
-
         int duration = melody.duration();
 
         // In singleplayer, cancel on item change (pause on scroll-away)
@@ -117,8 +115,11 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
 
         long prevPlaybackTime;
         long delta;
+        UUID uuid = null;
 
         if (multiplayerMode) {
+            uuid = Utils.getUUID(ref);
+
             // Sync: initialize shared time anchor on first tick
             if (progress.startWorldTime == 0) {
                 progress.startWorldTime = MelodySyncRegistry.getOrCreateAnchor(uuid, progress.melody, position, timeMs, duration);

--- a/src/main/java/net/conczin/data/MelodyProgress.java
+++ b/src/main/java/net/conczin/data/MelodyProgress.java
@@ -25,9 +25,16 @@ public final class MelodyProgress {
                     o -> o.time,
                     (o, p) -> o.time = p.time)
             .add()
+            .appendInherited(
+                    new KeyedCodec<>("StartWorldTime", Codec.LONG),
+                    (o, v) -> o.startWorldTime = v,
+                    o -> o.startWorldTime,
+                    (o, p) -> o.startWorldTime = p.startWorldTime)
+            .add()
             .build();
 
     public String melody = "";
     public long worldTime = 0;
     public long time = 0;
+    public long startWorldTime = 0;
 }

--- a/src/main/java/net/conczin/data/MelodySyncRegistry.java
+++ b/src/main/java/net/conczin/data/MelodySyncRegistry.java
@@ -1,0 +1,160 @@
+package net.conczin.data;
+
+import com.hypixel.hytale.math.vector.Vector3d;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class MelodySyncRegistry {
+    private static final long STALE_THRESHOLD_MS = 500L;
+    private static final double SYNC_RANGE = 40.0;
+    private static final double SYNC_RANGE_SQ = SYNC_RANGE * SYNC_RANGE;
+
+    private static final ConcurrentHashMap<String, List<SyncSession>> sessions = new ConcurrentHashMap<>();
+
+    private MelodySyncRegistry() {
+    }
+
+    public static long getOrCreateAnchor(UUID playerId, String melodyId, Vector3d position, long currentWorldTime, long melodyDurationMs) {
+        SyncSession[] matched = new SyncSession[1];
+        sessions.compute(melodyId, (key, existing) -> {
+            if (existing == null) {
+                existing = new ArrayList<>();
+            }
+
+            // Prune stale positions from all sessions; remove empty sessions
+            existing.removeIf(session -> {
+                session.pruneStalePositions(currentWorldTime, STALE_THRESHOLD_MS);
+                return session.playerPositions.isEmpty();
+            });
+
+            // Find session with closest active player within range
+            SyncSession closestSession = null;
+            double closestDistSq = Double.MAX_VALUE;
+            for (SyncSession session : existing) {
+                // Skip expired sessions so late joiners get a fresh anchor
+                if (currentWorldTime - session.startWorldTime > melodyDurationMs) continue;
+
+                double distSq = session.closestPlayerDistSq(position);
+                if (distSq <= SYNC_RANGE_SQ && distSq < closestDistSq) {
+                    closestDistSq = distSq;
+                    closestSession = session;
+                }
+            }
+            if (closestSession != null) {
+                closestSession.playerPositions.add(new ActivePosition(playerId, position, currentWorldTime));
+                matched[0] = closestSession;
+                return existing;
+            }
+
+            // No nearby session found — create a new one
+            SyncSession newSession = new SyncSession(playerId, currentWorldTime, position, currentWorldTime);
+            existing.add(newSession);
+            matched[0] = newSession;
+            return existing;
+        });
+        return matched[0].startWorldTime;
+    }
+
+    public static void removePlayer(UUID playerId, String melodyId) {
+        sessions.compute(melodyId, (key, existing) -> {
+            if (existing == null) return null;
+            for (SyncSession session : existing) {
+                session.playerPositions.removeIf(p -> p.playerId.equals(playerId));
+            }
+            existing.removeIf(session -> session.playerPositions.isEmpty());
+            return existing.isEmpty() ? null : existing;
+        });
+    }
+
+    public static void keepAlive(UUID playerId, String melodyId, long startWorldTime, Vector3d position, long currentWorldTime) {
+        sessions.compute(melodyId, (key, existing) -> {
+            if (existing == null) {
+                existing = new ArrayList<>();
+            }
+
+            // Find session by matching anchor
+            SyncSession target = null;
+            for (SyncSession session : existing) {
+                if (session.startWorldTime == startWorldTime) {
+                    target = session;
+                    break;
+                }
+            }
+
+            if (target != null) {
+                // Find position entry by player UUID
+                ActivePosition match = null;
+                for (ActivePosition p : target.playerPositions) {
+                    if (p.playerId.equals(playerId)) {
+                        match = p;
+                        break;
+                    }
+                }
+                if (match != null) {
+                    match.x = position.x;
+                    match.y = position.y;
+                    match.z = position.z;
+                    match.lastActiveTime = currentWorldTime;
+                } else {
+                    target.playerPositions.add(new ActivePosition(playerId, position, currentWorldTime));
+                }
+            } else {
+                // Session was pruned — re-create so this player is discoverable for sync
+                existing.add(new SyncSession(playerId, startWorldTime, position, currentWorldTime));
+            }
+
+            // Prune stale positions; remove empty sessions
+            existing.removeIf(session -> {
+                session.pruneStalePositions(currentWorldTime, STALE_THRESHOLD_MS);
+                return session.playerPositions.isEmpty();
+            });
+
+            return existing.isEmpty() ? null : existing;
+        });
+    }
+
+    private static final class ActivePosition {
+        final UUID playerId;
+        double x, y, z;
+        long lastActiveTime;
+
+        ActivePosition(UUID playerId, Vector3d position, long time) {
+            this.playerId = playerId;
+            this.x = position.x;
+            this.y = position.y;
+            this.z = position.z;
+            this.lastActiveTime = time;
+        }
+    }
+
+    private static final class SyncSession {
+        final long startWorldTime;
+        final List<ActivePosition> playerPositions = new ArrayList<>();
+
+        SyncSession(UUID playerId, long startWorldTime, Vector3d position, long currentTime) {
+            this.startWorldTime = startWorldTime;
+            this.playerPositions.add(new ActivePosition(playerId, position, currentTime));
+        }
+
+        void pruneStalePositions(long currentTime, long thresholdMs) {
+            playerPositions.removeIf(p -> currentTime - p.lastActiveTime > thresholdMs);
+        }
+
+        double closestPlayerDistSq(Vector3d position) {
+            double closestDistSq = Double.MAX_VALUE;
+            for (ActivePosition p : playerPositions) {
+                double dx = position.x - p.x;
+                double dy = position.y - p.y;
+                double dz = position.z - p.z;
+                double distSq = dx * dx + dy * dy + dz * dz;
+                if (distSq < closestDistSq) {
+                    closestDistSq = distSq;
+                }
+            }
+            return closestDistSq;
+        }
+    }
+}

--- a/src/main/java/net/conczin/data/MelodySyncRegistry.java
+++ b/src/main/java/net/conczin/data/MelodySyncRegistry.java
@@ -3,145 +3,73 @@ package net.conczin.data;
 import com.hypixel.hytale.math.vector.Vector3d;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class MelodySyncRegistry {
     private static final long STALE_THRESHOLD_MS = 500L;
-    private static final double SYNC_RANGE = 40.0;
-    private static final double SYNC_RANGE_SQ = SYNC_RANGE * SYNC_RANGE;
+    private static final double SYNC_RANGE_SQ = 40.0 * 40.0;
 
-    private static final ConcurrentHashMap<String, List<SyncSession>> sessions = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, List<Anchor>> anchors = new ConcurrentHashMap<>();
 
     private MelodySyncRegistry() {
     }
 
     public static long getOrCreateAnchor(UUID playerId, String melodyId, Vector3d position, long currentWorldTime, long melodyDurationMs) {
-        SyncSession[] matched = new SyncSession[1];
-        sessions.compute(melodyId, (key, existing) -> {
-            if (existing == null) {
-                existing = new ArrayList<>();
-            }
+        long[] result = new long[1];
+        anchors.compute(melodyId, (key, list) -> {
+            if (list == null) list = new ArrayList<>();
 
-            // Prune stale positions from all sessions; remove empty sessions
-            existing.removeIf(session -> {
-                session.pruneStalePositions(currentWorldTime, STALE_THRESHOLD_MS);
-                return session.playerPositions.isEmpty();
-            });
-
-            // Find session with closest active player within range
-            SyncSession closestSession = null;
+            // Single pass: prune stale entries and find closest active anchor
+            Anchor closest = null;
             double closestDistSq = Double.MAX_VALUE;
-            for (SyncSession session : existing) {
-                // Skip expired sessions so late joiners get a fresh anchor
-                if (currentWorldTime - session.startWorldTime > melodyDurationMs) continue;
-
-                double distSq = session.closestPlayerDistSq(position);
+            Iterator<Anchor> it = list.iterator();
+            while (it.hasNext()) {
+                Anchor a = it.next();
+                if (currentWorldTime - a.lastActive > STALE_THRESHOLD_MS) {
+                    it.remove();
+                    continue;
+                }
+                if (currentWorldTime - a.startWorldTime > melodyDurationMs) continue;
+                double distSq = a.distSq(position);
                 if (distSq <= SYNC_RANGE_SQ && distSq < closestDistSq) {
                     closestDistSq = distSq;
-                    closestSession = session;
+                    closest = a;
                 }
             }
-            if (closestSession != null) {
-                closestSession.playerPositions.add(new ActivePosition(playerId, position, currentWorldTime));
-                matched[0] = closestSession;
-                return existing;
-            }
 
-            // No nearby session found — create a new one
-            SyncSession newSession = new SyncSession(playerId, currentWorldTime, position, currentWorldTime);
-            existing.add(newSession);
-            matched[0] = newSession;
-            return existing;
+            // Sync to nearby player's anchor or start fresh
+            long startTime = closest != null ? closest.startWorldTime : currentWorldTime;
+            list.add(new Anchor(playerId, startTime, position.x, position.y, position.z, currentWorldTime));
+            result[0] = startTime;
+            return list;
         });
-        return matched[0].startWorldTime;
+        return result[0];
     }
 
     public static void removePlayer(UUID playerId, String melodyId) {
-        sessions.compute(melodyId, (key, existing) -> {
-            if (existing == null) return null;
-            for (SyncSession session : existing) {
-                session.playerPositions.removeIf(p -> p.playerId().equals(playerId));
-            }
-            existing.removeIf(session -> session.playerPositions.isEmpty());
-            return existing.isEmpty() ? null : existing;
+        anchors.computeIfPresent(melodyId, (key, list) -> {
+            list.removeIf(a -> a.playerId.equals(playerId));
+            return list.isEmpty() ? null : list;
         });
     }
 
     public static void keepAlive(UUID playerId, String melodyId, long startWorldTime, Vector3d position, long currentWorldTime) {
-        sessions.compute(melodyId, (key, existing) -> {
-            if (existing == null) {
-                existing = new ArrayList<>();
-            }
-
-            // Find session by matching anchor
-            SyncSession target = null;
-            for (SyncSession session : existing) {
-                if (session.startWorldTime == startWorldTime) {
-                    target = session;
-                    break;
-                }
-            }
-
-            if (target != null) {
-                boolean found = false;
-                for (int i = 0; i < target.playerPositions.size(); i++) {
-                    if (target.playerPositions.get(i).playerId().equals(playerId)) {
-                        target.playerPositions.set(i, new ActivePosition(playerId, position, currentWorldTime));
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    target.playerPositions.add(new ActivePosition(playerId, position, currentWorldTime));
-                }
-            } else {
-                // Session was pruned — re-create so this player is discoverable for sync
-                existing.add(new SyncSession(playerId, startWorldTime, position, currentWorldTime));
-            }
-
-            // Prune stale positions; remove empty sessions
-            existing.removeIf(session -> {
-                session.pruneStalePositions(currentWorldTime, STALE_THRESHOLD_MS);
-                return session.playerPositions.isEmpty();
-            });
-
-            return existing.isEmpty() ? null : existing;
+        anchors.compute(melodyId, (key, list) -> {
+            if (list == null) list = new ArrayList<>();
+            // Single pass: remove this player's old entry and prune stale anchors
+            list.removeIf(a -> a.playerId.equals(playerId) || currentWorldTime - a.lastActive > STALE_THRESHOLD_MS);
+            list.add(new Anchor(playerId, startWorldTime, position.x, position.y, position.z, currentWorldTime));
+            return list;
         });
     }
 
-    private record ActivePosition(UUID playerId, double x, double y, double z, long lastActiveTime) {
-        ActivePosition(UUID playerId, Vector3d position, long time) {
-            this(playerId, position.x, position.y, position.z, time);
-        }
-    }
-
-    private static final class SyncSession {
-        final long startWorldTime;
-        final List<ActivePosition> playerPositions = new ArrayList<>();
-
-        SyncSession(UUID playerId, long startWorldTime, Vector3d position, long currentTime) {
-            this.startWorldTime = startWorldTime;
-            this.playerPositions.add(new ActivePosition(playerId, position, currentTime));
-        }
-
-        void pruneStalePositions(long currentTime, long thresholdMs) {
-            playerPositions.removeIf(p -> currentTime - p.lastActiveTime() > thresholdMs);
-        }
-
-        double closestPlayerDistSq(Vector3d position) {
-            double closestDistSq = Double.MAX_VALUE;
-            for (ActivePosition p : playerPositions) {
-                double dx = position.x - p.x();
-                double dy = position.y - p.y();
-                double dz = position.z - p.z();
-                double distSq = dx * dx + dy * dy + dz * dz;
-                if (distSq < closestDistSq) {
-                    closestDistSq = distSq;
-                }
-            }
-            return closestDistSq;
+    private record Anchor(UUID playerId, long startWorldTime, double x, double y, double z, long lastActive) {
+        double distSq(Vector3d pos) {
+            double dx = pos.x - x, dy = pos.y - y, dz = pos.z - z;
+            return dx * dx + dy * dy + dz * dz;
         }
     }
 }

--- a/src/main/java/net/conczin/gui/MelodySelectionGui.java
+++ b/src/main/java/net/conczin/gui/MelodySelectionGui.java
@@ -14,6 +14,7 @@ import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import net.conczin.data.Melody;
 import net.conczin.data.MelodyAsset;
+import net.conczin.data.MelodyPlaybackInteraction;
 import net.conczin.data.MelodyProgress;
 import net.conczin.data.MelodySyncRegistry;
 import net.conczin.data.YmmersiveMelodiesRegistry;
@@ -179,12 +180,13 @@ public class MelodySelectionGui extends CodecDataInteractiveUIPage<MelodySelecti
 
     private void setMelody(Ref<EntityStore> ref, String selectedMelody) {
         MelodyProgress progress = Utils.getData(ref, "MelodyProgress", MelodyProgress.CODEC);
-        if (!progress.melody.isEmpty()) {
+        if (!progress.melody.isEmpty() && MelodyPlaybackInteraction.multiplayerMode) {
             MelodySyncRegistry.removePlayer(Utils.getUUID(ref), progress.melody);
         }
         progress.melody = selectedMelody;
         progress.time = 0;
         progress.startWorldTime = 0;
+        progress.worldTime = 0;
         Utils.setData(ref, "MelodyProgress", MelodyProgress.CODEC, progress);
         this.selectedMelody = selectedMelody;
     }

--- a/src/main/java/net/conczin/gui/MelodySelectionGui.java
+++ b/src/main/java/net/conczin/gui/MelodySelectionGui.java
@@ -180,7 +180,7 @@ public class MelodySelectionGui extends CodecDataInteractiveUIPage<MelodySelecti
 
     private void setMelody(Ref<EntityStore> ref, String selectedMelody) {
         MelodyProgress progress = Utils.getData(ref, "MelodyProgress", MelodyProgress.CODEC);
-        if (!progress.melody.isEmpty() && MelodyPlaybackInteraction.multiplayerMode) {
+        if (!progress.melody.isEmpty()) {
             MelodySyncRegistry.removePlayer(Utils.getUUID(ref), progress.melody);
         }
         progress.melody = selectedMelody;

--- a/src/main/java/net/conczin/gui/MelodySelectionGui.java
+++ b/src/main/java/net/conczin/gui/MelodySelectionGui.java
@@ -15,6 +15,7 @@ import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import net.conczin.data.Melody;
 import net.conczin.data.MelodyAsset;
 import net.conczin.data.MelodyProgress;
+import net.conczin.data.MelodySyncRegistry;
 import net.conczin.data.YmmersiveMelodiesRegistry;
 import net.conczin.utils.RecordCodec;
 import net.conczin.utils.Utils;
@@ -178,8 +179,12 @@ public class MelodySelectionGui extends CodecDataInteractiveUIPage<MelodySelecti
 
     private void setMelody(Ref<EntityStore> ref, String selectedMelody) {
         MelodyProgress progress = Utils.getData(ref, "MelodyProgress", MelodyProgress.CODEC);
+        if (!progress.melody.isEmpty()) {
+            MelodySyncRegistry.removePlayer(Utils.getUUID(ref), progress.melody);
+        }
         progress.melody = selectedMelody;
         progress.time = 0;
+        progress.startWorldTime = 0;
         Utils.setData(ref, "MelodyProgress", MelodyProgress.CODEC, progress);
         this.selectedMelody = selectedMelody;
     }


### PR DESCRIPTION
Features:
- Multiplayer melody sync — nearby players playing the same song hear it in time
- Singleplayer/multiplayer mode — auto-detects based on server access type

Fixes (pre-existing bugs):
- Fixed Note codec using wrong getter for length field (was reading time instead of length)
- Added auto-stop when song finishes (previously played forever silently)

How:
- Players within 40 blocks playing the same melody sync to a shared time anchor
- If multiple sessions exist for the same melody, the closest one is chosen
- Late joiners snap to the existing playback position
- When all players leave range or stop, the session cleans up automatically
- In singleplayer, sync is disabled and playback pauses when you switch items
- Core logic lives in MelodySyncRegistry


Trade-off: In multiplayer, pausing playback by switching items is no longer possible. This is caused by the sync implementation — a shared time anchor can't pause per-player. To mitigate this, the code auto-detects singleplayer mode and preserves the original pause-on-switch behavior there. Also detects mid-game switches to LAN.