### PR TITLE
Fix NoSuchMethodError crash when playing a sound in-game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+### Gradle ###
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### Hytale ###
+run/
+hytaleServer/
+libs/
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 1.1.1
+
+* Fixed crash when trying to play a title.
+* Updated server version 2026.03.25-89796E57B
+
 # 1.1.0
 
 * Added syncing of melodies with neighboring players

--- a/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
+++ b/src/main/java/net/conczin/data/MelodyPlaybackInteraction.java
@@ -28,6 +28,7 @@ import net.conczin.utils.Utils;
 
 import javax.annotation.Nonnull;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -207,7 +208,7 @@ public class MelodyPlaybackInteraction extends SimpleInteraction {
         SpatialResource<Ref<EntityStore>, EntityStore> spatialresource = componentAccessor.getResource(
                 EntityModule.get().getPlayerSpatialResourceType()
         );
-        List<Ref<EntityStore>> list = SpatialResource.getThreadLocalReferenceList();
+        List<Ref<EntityStore>> list = new ArrayList<>();
         spatialresource.getSpatialStructure().collect(position, soundevent.getMaxDistance(), list);
         for (Ref<EntityStore> ref : list) {
             PlayerRef playerref = componentAccessor.getComponent(ref, PlayerRef.getComponentType());

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -8,11 +8,15 @@
       "Name": "Conczin",
       "Email": "conczin@gmail.com",
       "Url": "https://conczin.net/"
+    },
+    {
+      "Name": "GlobalHive",
+      "Email": "support@globalhive.ch"
     }
   ],
   "Website": "https://conczin.net/",
   "Main": "net.conczin.YmmersiveMelodies",
-  "ServerVersion": "2026.02.19-1a311a592",
+  "ServerVersion": "2026.03.25-89796E57B",
   "Dependencies": {},
   "OptionalDependencies": {},
   "DisabledByDefault": false,

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -16,7 +16,7 @@
   ],
   "Website": "https://conczin.net/",
   "Main": "net.conczin.YmmersiveMelodies",
-  "ServerVersion": "2026.03.25-89796E57B",
+  "ServerVersion": "2026.03.26-89796e57b",
   "Dependencies": {},
   "OptionalDependencies": {},
   "DisabledByDefault": false,


### PR DESCRIPTION
The Hytale server API removed `SpatialResource.getThreadLocalReferenceList()` in a recent update (2026.03.26)
This caused a NoSuchMethodError that kicked the player from the world every time a melody tried to play a sound.

**Changes:**

Replaced `SpatialResource.getThreadLocalReferenceList()` with `new ArrayList<>()` in `MelodyPlaybackInteraction.java`

The list is used as a scratch buffer for collecting nearby player refs, so a fresh list per call is functionally equivalent without relying on the removed thread-local pool.
Bumped the target server version in manifest.json to 2026.03.26-89796e57b.